### PR TITLE
Fix keywords in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scientisto"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Tibor Csóka"]
 license = "MIT"
 edition = "2021"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ description = "A light-weight Rust implementation of the github/scientist librar
 documentation = "https://teebor-choka.github.io/scientisto/scientisto/index.html"
 homepage = "https://teebor-choka.github.io/scientisto/scientisto/index.html"
 repository = "https://github.com/Teebor-Choka/scientisto"
-keywords = ["scientist", "refactoring", "github", "critical paths"]
+keywords = ["scientist", "refactoring", "github", "critical"]
 categories = ["rust-patterns"]
 exclude = [".github/", "codecov.yml"]
 


### PR DESCRIPTION
## What
Fix keywords to allow publishing to crates.io.

Bump version to 0.1.1