### PR TITLE
Update minor version to be compliant with semver

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scientisto"
-version = "0.1.4"
+version = "0.2.0"
 authors = ["Tibor Csóka"]
 license = "MIT"
 edition = "2021"


### PR DESCRIPTION
## What
The last PR introduced changes that force a minor version bump. The API is stable, but the ABI was changed.